### PR TITLE
Standardized logging enviroment so we get mozlog logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ chardet==3.0.4
 cookies==2.2.1
 cryptography==2.2.2
 docker==3.2.1
+dockerflow==2018.4.0
 docker-pycreds==0.2.2
 docutils==0.14
 idna==2.6
@@ -21,7 +22,7 @@ MarkupSafe==1.0
 mock==2.0.0
 more-itertools==4.1.0
 moto==1.3.1
-mozilla-srgutil==0.1.5
+mozilla-srgutil==0.1.6
 numpy==1.14.2
 pbr==4.0.2
 pkginfo==1.4.2

--- a/taar_lite/recommenders/guid_based_recommender.py
+++ b/taar_lite/recommenders/guid_based_recommender.py
@@ -2,13 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import logging
-from srgutil.interfaces import IS3Data
+from srgutil.interfaces import IS3Data, IMozLogging
 
 ADDON_LIST_BUCKET = 'telemetry-parquet'
 ADDON_LIST_KEY = 'taar/lite/guid_coinstallation.json'
-
-logger = logging.getLogger(__name__)
 
 
 class GuidBasedRecommender:
@@ -43,14 +40,16 @@ class GuidBasedRecommender:
 
     def _init_from_ctx(self):
         cache = self._ctx[IS3Data]
+        self.logger = self._ctx[IMozLogging]
+
         self._addons_coinstallations = cache.get_s3_json_content(ADDON_LIST_BUCKET,
                                                                  ADDON_LIST_KEY)
         if self._addons_coinstallations is None:
-            logger.error("Cannot download the addon coinstallation file {}".format(ADDON_LIST_KEY))
+            self.logger.error("Cannot download the addon coinstallation file {}".format(ADDON_LIST_KEY))
 
     def _precompute_normalization(self):
         if self._addons_coinstallations is None:
-            logger.error("Cannot find addon coinstallations to normalize.")
+            self.logger.error("Cannot find addon coinstallations to normalize.")
             return
 
         # Capture the total number of times that a guid was
@@ -122,7 +121,7 @@ class GuidBasedRecommender:
         if normalize is not None and normalize not in norm_dict.keys():
             # Yield no results if the normalization method is not
             # specified
-            logger.warn("Invalid normalization parameter detected: [%s]" % normalize)
+            self.logger.warn("Invalid normalization parameter detected: [%s]" % normalize)
             return []
 
         result_dict = self._addons_coinstallations.get(addon_guid, {})


### PR DESCRIPTION
I've added support for standard MozLog JSON format logging to srgutil.  This just hooks the logging subsystem and replaces the logger in GuidBasedRecommender.