### PR TITLE
Adds installation rate as a second sort parameter 

### DIFF
--- a/taar_lite/recommenders/guid_based_recommender.py
+++ b/taar_lite/recommenders/guid_based_recommender.py
@@ -152,7 +152,12 @@ class GuidBasedRecommender:
         tmp_result_dict = norm_method(addon_guid, result_dict)
 
         # Augment the result_dict with the installation counts
-        # and then we can sort better
+        # and then we can sort using lexical sorting of strings.
+        # The idea here is to get something in the form of
+        #    0000.0000.0000
+        # The computed weight takes the first and second segments of
+        # integers.  The third segment is the installation count of
+        # the addon but is zero padded.
         result_dict = {}
         for k, v in tmp_result_dict.items():
             lex_value = "{0:020.10f}.{1:010d}".format(v, self._guid_rankings.get(k, 0))

--- a/taar_lite/recommenders/guid_based_recommender.py
+++ b/taar_lite/recommenders/guid_based_recommender.py
@@ -6,6 +6,7 @@ from srgutil.interfaces import IS3Data, IMozLogging
 
 ADDON_LIST_BUCKET = 'telemetry-parquet'
 ADDON_LIST_KEY = 'taar/lite/guid_coinstallation.json'
+GUID_RANKING_KEY = 'taar/lite/guid_install_ranking.json'
 
 
 NORM_MODE_ROWNORMSUM = 'rownorm_sum'
@@ -53,6 +54,9 @@ class GuidBasedRecommender:
 
         self._addons_coinstallations = cache.get_s3_json_content(ADDON_LIST_BUCKET,
                                                                  ADDON_LIST_KEY)
+
+        self._guid_rankings = cache.get_s3_json_content(ADDON_LIST_BUCKET,
+                                                        GUID_RANKING_KEY)
         if self._addons_coinstallations is None:
             msg = "Cannot download addon coinstallation file {}".format(ADDON_LIST_KEY)
             self.logger.error(msg)
@@ -145,7 +149,14 @@ class GuidBasedRecommender:
         result_dict = self._addons_coinstallations.get(addon_guid, {})
 
         # Apply normalization
-        result_dict = norm_method(addon_guid, result_dict)
+        tmp_result_dict = norm_method(addon_guid, result_dict)
+
+        # Augment the result_dict with the installation counts
+        # and then we can sort better
+        result_dict = {}
+        for k, v in tmp_result_dict.items():
+            lex_value = "{0:020.10f}.{1:010d}".format(v, self._guid_rankings.get(k, 0))
+            result_dict[k] = lex_value
 
         # Sort the result dictionary in descending order by weight
         result_list = sorted(result_dict.items(), key=lambda x: x[1], reverse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,44 @@ def MOCK_DATA():
 
 
 @pytest.fixture
+def TIE_MOCK_DATA():
+    return {"guid-1": {'guid-2': 100,
+                       'guid-3': 100,
+                       'guid-4': 100,
+                       'guid-5': 100},
+            'guid-2': {'guid-1': 100,
+                       'guid-3': 100,
+                       'guid-4': 100,
+                       'guid-5': 100},
+            'guid-3': {'guid-1': 100,
+                       'guid-2': 100,
+                       'guid-4': 100,
+                       'guid-5': 100},
+            'guid-4': {'guid-1': 20,
+                       'guid-2': 20,
+                       'guid-3': 20,
+                       'guid-5': 20},
+            'guid-5': {'guid-1': 20,
+                       'guid-2': 20,
+                       'guid-3': 20,
+                       'guid-4': 20},
+            }
+
+
+@pytest.fixture
+def MOCK_GUID_RANKING():
+    return {"guid-1": 10,
+            'guid-2': 9,
+            'guid-3': 8,
+            'guid-4': 7,
+            'guid-5': 6,
+            "guid-6": 5,
+            'guid-7': 4,
+            'guid-8': 3,
+            'guid-9': 2}
+
+
+@pytest.fixture
 def default_ctx():
     """
     This sets up a basic context for use for testing

--- a/tests/test_guid_based_recommender.py
+++ b/tests/test_guid_based_recommender.py
@@ -18,6 +18,17 @@ from taar_lite.recommenders.guid_based_recommender import GUID_RANKING_KEY
 # method appears to provide qualitatively better results than the
 # other normalization modes including no normalization.
 
+
+# Reading the RESULTS is not entirely obvious.  The recommendation
+# list consists of 2-tuples containing a guid, followed by a lexically
+# sorted weight+install count.
+# The weights are formatted as a fixed with zero padded float, with
+# an addition suffix of a decimal and a zero padded instllation count
+# for the addon.
+#
+# The clearest example of this is the 'rownorm_sum_tiebreak' results
+# where each of the computed weights are the same (0.25), but the
+# installation count varies.
 RESULTS = {
     'default': [('guid-2', '000001000.0000000000.0000000009'),
                 ('guid-3', '000000100.0000000000.0000000008'),
@@ -162,5 +173,5 @@ def test_rownorm_sum_tiebreak(default_ctx, TIE_MOCK_DATA, MOCK_GUID_RANKING):
     actual = recommender.recommend({'guid': guid, 'normalize': 'rownorm_sum'})
 
     # Note that the results have weights that are equal, but the tie
-    # break is solved by the install rate
+    # break is solved by the install rate.
     assert actual == EXPECTED_RESULTS


### PR DESCRIPTION
This should fix #3.

The add-on recommendations are now sorted primarily by weight, and total installation is used as a secondary index.

The installation number is currently *not* normalized, but that shouldn't matter in the context of sorting add-on recommendations. 

Note that this relies on a JSON file generated in https://github.com/mozilla/python_mozetl/pull/225