### PR TITLE
init commit for issue #16 to pregenerate the TAARlite recommendations

### DIFF
--- a/scripts/pregenerate.py
+++ b/scripts/pregenerate.py
@@ -30,6 +30,7 @@ def compute_name(guid, addon_data):
 output = {}
 for guid in addon_whitelist.keys():
     addon_data = addon_whitelist.get(guid, None)
+    addon_url = addon_data['url']
     addon_name = compute_name(guid, addon_data)
 
     recommendations = [x[0] for x in grec.recommend({'guid': guid}, limit=10)]
@@ -47,15 +48,17 @@ for guid in addon_whitelist.keys():
                 # In this case, just skip this recommendation
                 continue
             rec_name = compute_name(rec_guid, rec_data)
-            suggestions.append({'recommendation_name': rec_name, 'recommendation_guid': rec_guid})
+            rec_url = rec_data['url']
+            suggestions.append({'recommendation_name': rec_name,
+                                'recommendation_url': rec_url,
+                                'recommendation_guid': rec_guid})
 
         # Strip down the suggestions to length 4 to work around the
         # coinstallation json bug
         suggestions = suggestions[:4]
 
         if len(suggestions) == 4:
-            output[guid] = {'name': addon_name,
-                            'suggestions': suggestions}
+            output[addon_url] = {'addon_name': addon_name, 'suggestions': suggestions}
         else:
             print("Skipping {0}-{1} because of coinstallation bug".format(guid, addon_name))
 

--- a/scripts/pregenerate.py
+++ b/scripts/pregenerate.py
@@ -1,0 +1,62 @@
+"""
+Pregenerate addon recommendation results for all whitelisted addons.
+"""
+
+import json
+
+from srgutil.context import default_context
+from srgutil.interfaces import IS3Data
+from taar_lite.recommenders import GuidBasedRecommender
+
+ADDON_LIST_BUCKET = 'telemetry-parquet'
+WHITELIST_KEY = 'telemetry-ml/addon_recommender/whitelist_addons_database.json'
+
+
+ctx = default_context()
+cache = ctx[IS3Data]
+
+addon_whitelist = cache.get_s3_json_content(ADDON_LIST_BUCKET,
+                                            WHITELIST_KEY)
+grec = GuidBasedRecommender(ctx)
+
+
+def compute_name(guid, addon_data):
+    guid_name = addon_data['name'].get('en-US', None)
+    if guid_name is None:
+        guid_name = list(addon_data['name'].values())[0]
+    return guid_name
+
+
+output = {}
+for guid in addon_whitelist.keys():
+    addon_data = addon_whitelist.get(guid, None)
+    addon_name = compute_name(guid, addon_data)
+
+    recommendations = [x[0] for x in grec.recommend({'guid': guid}, limit=10)]
+    if len(recommendations) == 4:
+        suggestions = []
+        for rec_guid in recommendations:
+            rec_data = addon_whitelist.get(rec_guid, None)
+            if rec_data is None:
+                # A recommendation generated a non-whitelisted addon.
+                # This shouldn't happen in production, but taar-lite
+                # has a bug in dev where the guid_coinstallation.json
+                # file was generated before we added filtering for
+                # legacy add-ons.
+                #
+                # In this case, just skip this recommendation
+                continue
+            rec_name = compute_name(rec_guid, rec_data)
+            suggestions.append({'recommendation_name': rec_name, 'recommendation_guid': rec_guid})
+
+        # Strip down the suggestions to length 4 to work around the
+        # coinstallation json bug
+        suggestions = suggestions[:4]
+
+        if len(suggestions) == 4:
+            output[guid] = {'name': addon_name,
+                            'suggestions': suggestions}
+        else:
+            print("Skipping {0}-{1} because of coinstallation bug".format(guid, addon_name))
+
+json.dump(output, open('/tmp/taarlite_pregenerated.json', 'w'), indent=2)


### PR DESCRIPTION
This adds a script to pregenerate all TAARlite recommendations in a JSON file in /tmp with human readable names as well as GUID for addons.mozilla.org review.

This should close off #16 