### PR TITLE
Features/35 user agent strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
 - pip install -r test_requirements.txt
 
 script:
-- flake8  --max-line-length=100 taar_lite tests || exit 1  # Fail if flake8 fails
+- flake8  --max-line-length=120 taar_lite tests || exit 1  # Fail if flake8 fails
 - py.test --cov taar_lite tests

--- a/taar_lite/recommenders/ua_parser.py
+++ b/taar_lite/recommenders/ua_parser.py
@@ -1,0 +1,28 @@
+import re
+
+RE_PLATFORM = re.compile('(linux|windows|macintosh|android|fxios).*firefox')
+
+LINUX = 1
+WINDOWS = 2
+MACINTOSH = 3
+ANDROID = 4
+FXIOS = 5
+
+OSNAME_TO_ID = {'linux': LINUX,
+                'windows': WINDOWS,
+                'macintosh': MACINTOSH,
+                'android': ANDROID,
+                'fxios': FXIOS}
+
+
+def parse_ua(user_agent):
+    """
+    Return one of the constants for platform selection, otherwise
+    return None if the platform cannot be determined.  Any non-firefox
+    agent us automatically short circuited to be None.
+    """
+    ua = user_agent.lower()
+    matches = RE_PLATFORM.findall(ua)
+    if len(matches) != 1:
+        return None
+    return OSNAME_TO_ID[matches[0]]

--- a/tests/test_guid_based_recommender.py
+++ b/tests/test_guid_based_recommender.py
@@ -11,6 +11,8 @@ from taar_lite.recommenders.guid_based_recommender import GUID_RANKING_KEY
 
 from taar_lite.recommenders.cache import LazyJSONLoader
 
+from taar_lite.recommenders.ua_parser import parse_ua, OSNAME_TO_ID
+
 # The different kinds of results we can expect from TAARlite are
 # listed below.  Note that the ordering of GUIDs returned, and even
 # the set of GUIDs returned may be altered by the different weight
@@ -240,3 +242,38 @@ def test_divide_by_zero_rownorm_data_issue_31(default_ctx, TIE_MOCK_DATA, MOCK_G
     actual = recommender.recommend({'guid': guid, 'normalize': 'rownorm_sum'})
 
     assert actual == EXPECTED_RESULTS
+
+
+def test_user_agent_strings():
+    """
+    The UA String parser should only care about selecting the right
+    platform for Firefox UA strings.  Any non-firefox browser should
+    get all available addons.
+    """
+    ua_strings = {
+            'windows': "Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0",
+            'macintosh': "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:60.0) Gecko/20100101 Firefox/60.0",
+            'linux': "Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0",
+            'android': "Mozilla/5.0 (Android; Mobile; rv:40.0) Gecko/40.0 Firefox/40.0",
+            }
+
+    not_fx_ua_strings = [
+    # Chrome
+    "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36",  # noqa
+
+    # Microsoft Edge
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",  # noqa
+
+    # Safari
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A",  # noqa
+    ]
+
+    # These are valid Firefox UA strings
+    for platform, ua in ua_strings.items():
+        platform_id = parse_ua(ua)
+        assert OSNAME_TO_ID[platform] == platform_id
+
+    # These are non-Firefox UA strings - we should expect nothing
+    for ua in not_fx_ua_strings:
+        actual_name = parse_ua(ua)
+        assert actual_name is None


### PR DESCRIPTION
WIP PR for UA string parsing for #35

@muffinresearch - we're going to need to have the AMO server pass in a complete user-agent string into taar.   I'm explicitly parsing out the platform for Firefox user-agents.  For any UA that looks like it's not Firefox - or ambiguous platform - I'm just selecting all platforms.